### PR TITLE
Better pixelization

### DIFF
--- a/Assets/Scripts/General/CommonShaderRenderFunctions.cs
+++ b/Assets/Scripts/General/CommonShaderRenderFunctions.cs
@@ -41,7 +41,7 @@ namespace CommonShaderRenderFunctions
 
             if (texture == null || texture.width != Screen.width / MathFunctions.IntPow(pixelizationBase, pixelizationLevel) || texture.height != Screen.height / MathFunctions.IntPow(pixelizationBase, pixelizationLevel) || additionalCondition)
             {
-
+                
                 if (texture != null)
                     texture.Release();
 
@@ -52,7 +52,7 @@ namespace CommonShaderRenderFunctions
                 };
                 texture.Create();
 
-
+                Debug.Log($"W: {texture.width} H: {texture.height} Screen: {Screen.width} x {Screen.height}");
             }
             return texture;
         }
@@ -61,9 +61,9 @@ namespace CommonShaderRenderFunctions
         {
             int RenderThreadGrupsX = Mathf.CeilToInt(Screen.width / 8);
             int RenderThreadGrupsY = Mathf.CeilToInt(Screen.height / 8);
-            int CalculatethreadGroupsX = Mathf.CeilToInt(Screen.width / (8 * MathFunctions.IntPow(pixelizationBase, pixelizationLevel)));
-            int CalculatethreadGroupsY = Mathf.CeilToInt(Screen.height / (8 * MathFunctions.IntPow(pixelizationBase, pixelizationLevel)));
-
+            int CalculatethreadGroupsX = Mathf.CeilToInt((float)Screen.width / (8 * MathFunctions.IntPow(pixelizationBase, pixelizationLevel)));
+            int CalculatethreadGroupsY = Mathf.CeilToInt((float)Screen.height / (8 * MathFunctions.IntPow(pixelizationBase, pixelizationLevel)));
+            Debug.Log($"Render: {RenderThreadGrupsX} x {RenderThreadGrupsY} calculate: {CalculatethreadGroupsX} x {CalculatethreadGroupsY}");
 
             DummyShader.SetTexture(0, "Result", dummyTexture);
             DummyShader.Dispatch(0, CalculatethreadGroupsX, CalculatethreadGroupsY, 1);
@@ -106,10 +106,7 @@ namespace CommonShaderRenderFunctions
 
                 oldIdx = cornerY * oldDataWidth + cornerX;
                 newIdx = 0;
-                oldIdx += oldDataWidth * oldDataHeight * pixelizationData.register;
-                newIdx += newDataWidth * newDataHeight * pixelizationData.register;
-                oldIdx *= arrayCount;
-                newIdx *= arrayCount;
+              
 
                 yLoops = newDataHeight;
                 xLoops = newDataWidth;
@@ -122,15 +119,15 @@ namespace CommonShaderRenderFunctions
                 
                 oldIdx = 0;
                 newIdx = cornerY * newDataWidth + cornerX;
-                oldIdx += oldDataWidth * oldDataHeight * pixelizationData.register;
-                newIdx += newDataWidth * newDataHeight * pixelizationData.register;
-                oldIdx *= arrayCount;
-                newIdx *= arrayCount;
+           
                 yLoops = oldDataHeight;
                 xLoops = oldDataWidth;
 
             }
-
+            oldIdx += oldDataWidth * oldDataHeight * pixelizationData.register;
+            newIdx += newDataWidth * newDataHeight * pixelizationData.register;
+            oldIdx *= arrayCount;
+            newIdx *= arrayCount;
             for (int y = 0; y < yLoops; y++)
             {
                 for (int x = 0; x < xLoops; x++)

--- a/Assets/Scripts/General/CommonShaderRenderFunctions.cs
+++ b/Assets/Scripts/General/CommonShaderRenderFunctions.cs
@@ -5,10 +5,10 @@ namespace CommonShaderRenderFunctions
 {
     class PixelizedShaders
     {
-        
-        public static RenderTexture InitializePixelizedTexture(RenderTexture texture,int pixelizationBase,int pixelizationLevel,bool additionalCondition=false)
+
+        public static RenderTexture InitializePixelizedTexture(RenderTexture texture, int pixelizationBase, int pixelizationLevel, bool additionalCondition = false)
         {
-           
+
             if (texture == null || texture.width != Screen.width / MathFunctions.IntPow(pixelizationBase, pixelizationLevel) || texture.height != Screen.height / MathFunctions.IntPow(pixelizationBase, pixelizationLevel) || additionalCondition)
             {
 
@@ -27,7 +27,7 @@ namespace CommonShaderRenderFunctions
             return texture;
         }
 
-        public static void Dispatch(ComputeShader RenderShader,ComputeShader DummyShader,RenderTexture targetTexture, RenderTexture dummyTexture,int pixelizationBase, int pixelizationLevel)
+        public static void Dispatch(ComputeShader RenderShader, ComputeShader DummyShader, RenderTexture targetTexture, RenderTexture dummyTexture, int pixelizationBase, int pixelizationLevel)
         {
             int RenderThreadGrupsX = Mathf.CeilToInt(Screen.width / 8);
             int RenderThreadGrupsY = Mathf.CeilToInt(Screen.height / 8);
@@ -37,11 +37,88 @@ namespace CommonShaderRenderFunctions
 
             DummyShader.SetTexture(0, "Result", dummyTexture);
             DummyShader.Dispatch(0, CalculatethreadGroupsX, CalculatethreadGroupsY, 1);
-          
+
 
             RenderShader.SetTexture(0, "Result", targetTexture);
             RenderShader.Dispatch(0, RenderThreadGrupsX, RenderThreadGrupsY, 1);
 
+        }
+
+        public static void HandleZoomPixelization<T>(ComputeBuffer oldBuffer,ComputeBuffer newBuffer,int sizeofT,bool zoomIn, int pixelsPerPixel,int lastPixelsPerPixel,int lastPixelCount, int pixelCount, int pixelizationBase, int register,Action<bool> resetSetCallback,Action<ComputeBuffer,ComputeBuffer> setBuffers)
+        {
+            T[] oldArr = new T[lastPixelCount * 2];
+            T[] newArr;
+            int dataWidth;
+            int dataHeigth;
+            int otherWidth;
+            int otherHeigth;
+            if (zoomIn)//zoom in
+            {
+                newArr = new T[pixelCount]; //Not yet sure but I think it should be *2
+                dataWidth = Screen.width / pixelsPerPixel;
+                dataHeigth = Screen.height / pixelsPerPixel;
+
+                otherWidth = Screen.width / lastPixelsPerPixel;
+                otherHeigth = Screen.height / lastPixelsPerPixel;
+
+            }
+            else //zoom out
+            {
+
+                newArr = new T[pixelCount * 2];
+
+
+                otherWidth = Screen.width / pixelsPerPixel;
+                otherHeigth = Screen.height / pixelsPerPixel;
+
+
+                dataWidth = Screen.width / lastPixelsPerPixel;
+                dataHeigth = Screen.height / lastPixelsPerPixel;
+            }
+
+            oldBuffer.GetData(oldArr);
+
+            int cornerX = dataWidth * (pixelizationBase - 1) / 2;
+            int cornerY = dataHeigth * (pixelizationBase - 1) / 2;
+            for (int x = 0; x < dataWidth; x++)
+            {
+                for (int y = 0; y < dataHeigth; y++)
+                {
+
+                    int smallId = x + y * dataWidth;
+                    int bigId = x + cornerX + (y + cornerY) * otherWidth;
+                    bigId += otherWidth * otherHeigth * register;
+                    if (!zoomIn)
+                    {
+                        smallId += dataWidth * dataHeigth * register;
+                    }
+
+
+                  
+                    if (zoomIn)
+                    {
+                        newArr[bigId] = oldArr[smallId];
+                    }
+                    else
+                    {
+                        newArr[smallId] = oldArr[bigId];
+                    }
+                    
+                }
+            }
+            oldBuffer.Dispose();
+            oldBuffer = new ComputeBuffer(pixelCount * 2, sizeofT);
+
+            if (!zoomIn)
+            {
+                resetSetCallback(false);
+                oldBuffer.SetData(newArr);
+            }
+            else
+            {
+                newBuffer.SetData(newArr);
+            }
+            setBuffers(oldBuffer, newBuffer);
         }
 
 

--- a/Assets/Scripts/General/CommonShaderRenderFunctions.cs
+++ b/Assets/Scripts/General/CommonShaderRenderFunctions.cs
@@ -3,6 +3,24 @@ using UnityEngine;
 using System;
 namespace CommonShaderRenderFunctions
 {
+    struct PixelizationData //shortcut to keep everything condensed
+    {
+        int pixelsPerPixel;
+        int lastPixelsPerPixel;
+        int pixelCount;
+        int lastPixelCount;
+        int pixelizationBase;
+        public PixelizationData(int pixelsPerPixel,int lastPixelsPerPixel, int pixelCount, int lastPixelCount, int pixelizationBase)
+        {
+            this.pixelsPerPixel = pixelsPerPixel;
+            this.lastPixelsPerPixel = lastPixelsPerPixel;
+            this.pixelCount = pixelCount;
+            this.lastPixelCount = lastPixelCount;
+            this.pixelizationBase = pixelizationBase;
+        }
+        
+
+    }
     class PixelizedShaders
     {
 
@@ -44,83 +62,10 @@ namespace CommonShaderRenderFunctions
 
         }
 
-        public static void HandleZoomPixelization<T>(ComputeBuffer oldBuffer,ComputeBuffer newBuffer,int sizeofT,bool zoomIn, int pixelsPerPixel,int lastPixelsPerPixel,int lastPixelCount, int pixelCount, int pixelizationBase, int register,Action<bool> resetSetCallback,Action<ComputeBuffer,ComputeBuffer> setBuffers)
+        public static void HandleZoomPixelization<T>(ComputeBuffer Buffer, int sizeofT, bool zoomIn, PixelizationData pixelizationData, int register, Action<bool> resetSetCallback, Action<ComputeBuffer> setBuffers, int arrayCount = 1)
         {
-            T[] oldArr = new T[lastPixelCount * 2];
-            T[] newArr;
-            int dataWidth;
-            int dataHeigth;
-            int otherWidth;
-            int otherHeigth;
-            if (zoomIn)//zoom in
-            {
-                newArr = new T[pixelCount]; //Not yet sure but I think it should be *2
-                dataWidth = Screen.width / pixelsPerPixel;
-                dataHeigth = Screen.height / pixelsPerPixel;
 
-                otherWidth = Screen.width / lastPixelsPerPixel;
-                otherHeigth = Screen.height / lastPixelsPerPixel;
-
-            }
-            else //zoom out
-            {
-
-                newArr = new T[pixelCount * 2];
-
-
-                otherWidth = Screen.width / pixelsPerPixel;
-                otherHeigth = Screen.height / pixelsPerPixel;
-
-
-                dataWidth = Screen.width / lastPixelsPerPixel;
-                dataHeigth = Screen.height / lastPixelsPerPixel;
-            }
-
-            oldBuffer.GetData(oldArr);
-
-            int cornerX = dataWidth * (pixelizationBase - 1) / 2;
-            int cornerY = dataHeigth * (pixelizationBase - 1) / 2;
-            for (int x = 0; x < dataWidth; x++)
-            {
-                for (int y = 0; y < dataHeigth; y++)
-                {
-
-                    int smallId = x + y * dataWidth;
-                    int bigId = x + cornerX + (y + cornerY) * otherWidth;
-                    bigId += otherWidth * otherHeigth * register;
-                    if (!zoomIn)
-                    {
-                        smallId += dataWidth * dataHeigth * register;
-                    }
-
-
-                  
-                    if (zoomIn)
-                    {
-                        newArr[bigId] = oldArr[smallId];
-                    }
-                    else
-                    {
-                        newArr[smallId] = oldArr[bigId];
-                    }
-                    
-                }
-            }
-            oldBuffer.Dispose();
-            oldBuffer = new ComputeBuffer(pixelCount * 2, sizeofT);
-
-            if (!zoomIn)
-            {
-                resetSetCallback(false);
-                oldBuffer.SetData(newArr);
-            }
-            else
-            {
-                newBuffer.SetData(newArr);
-            }
-            setBuffers(oldBuffer, newBuffer);
         }
-
 
     }
     class Antialiasing

--- a/Assets/Scripts/ShaderContolers/MandelbrotContoroler.cs
+++ b/Assets/Scripts/ShaderContolers/MandelbrotContoroler.cs
@@ -170,7 +170,7 @@ G - Toggle GUI";
     }
     PixelizationData GetPixelizationData()
     {
-        return new(PixelsPerPixel(), LastPixelsPerPixel(), PixelCount(), LastPixelCount(), pixelizationBase);
+        return new(PixelsPerPixel(), LastPixelsPerPixel(), PixelCount(), LastPixelCount(), pixelizationBase,register);
     }
 
     void ResetIterPerCycle()
@@ -454,10 +454,16 @@ G - Toggle GUI";
             IterBuffer = new ComputeBuffer(PixelCount(), sizeof(int) * 2 + sizeof(float));
             if (lastPixelizationLevel != pixelizationLevel && !upscaling)
             {
-               
-                PixelizedShaders.HandleZoomPixelization<int>(FpMultiframeBuffer, sizeof(int), lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), (ComputeBuffer buffer) => { FpMultiframeBuffer = buffer; }, shaderPixelSize);
-                PixelizedShaders.HandleZoomPixelization<DoublePixelPacket>(MultiFrameRenderBuffer, sizeof(double) * 2 + sizeof(int) * 2 + sizeof(float) * 2, lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), (ComputeBuffer buffer) => { MultiFrameRenderBuffer = buffer; });
-                Debug.Log(pixelizationLevel - lastPixelizationLevel);   
+                if (infinitePre)
+                {
+                    PixelizedShaders.HandleZoomPixelization<int>(FpMultiframeBuffer, sizeof(int), lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), (ComputeBuffer buffer) => { FpMultiframeBuffer = buffer; }, shaderPixelSize);
+                }
+                else
+                {
+                    PixelizedShaders.HandleZoomPixelization<DoublePixelPacket>(MultiFrameRenderBuffer, sizeof(double) * 2 + sizeof(int) * 2 + sizeof(float) * 2, lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), (ComputeBuffer buffer) => { MultiFrameRenderBuffer = buffer; });
+
+                }
+
             }
             else
             {

--- a/Assets/Scripts/ShaderContolers/MandelbrotContoroler.cs
+++ b/Assets/Scripts/ShaderContolers/MandelbrotContoroler.cs
@@ -450,96 +450,28 @@ G - Toggle GUI";
     {
         if (PrevScreenX != Screen.width || PrevScreenY != Screen.height || lastPixelizationLevel != pixelizationLevel)
         {
-            reset = true;
             IterBuffer.Dispose();
             IterBuffer = new ComputeBuffer(PixelCount(), sizeof(int) * 2 + sizeof(float));
-            MultiFrameRenderBuffer.Dispose();
-            MultiFrameRenderBuffer = new ComputeBuffer(PixelCount()*2, sizeof(double) * 2 + sizeof(int) * 2 + sizeof(float) * 2);
             if (lastPixelizationLevel != pixelizationLevel && !upscaling)
             {
-
-                PixelizedShaders.HandleZoomPixelization<int>(FpMultiframeBuffer,sizeof(int), lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), register, (bool b) => { reset = b; }, (ComputeBuffer buffer) => { FpMultiframeBuffer = buffer;},shaderPixelSize);
-                //int[] oldArr = new int[LastPixelCount()*2 * shaderPixelSize]; ;
-                //int[] newArr;
-                //int dataWidth;
-                //int dataHeigth;
-                //int otherWidth;
-                //int otherHeigth;
-                //if (lastPixelizationLevel < pixelizationLevel)//zoom in
-                //{
-                //    newArr = new int[PixelCount() * shaderPixelSize];
-                //    dataWidth = Screen.width / PixelsPerPixel();
-                //    dataHeigth = Screen.height / PixelsPerPixel();
-
-                //    otherWidth = Screen.width / LastPixelsPerPixel();
-                //    otherHeigth = Screen.height / LastPixelsPerPixel();
-
-                //}
-                //else //zoom out
-                //{
-
-                //    newArr = new int[PixelCount()*2 * shaderPixelSize];
-
-
-                //    otherWidth = Screen.width / PixelsPerPixel();
-                //    otherHeigth = Screen.height / PixelsPerPixel();
-
-
-                //    dataWidth = Screen.width / LastPixelsPerPixel();
-                //    dataHeigth = Screen.height / LastPixelsPerPixel();
-                //}
-
-                //FpMultiframeBuffer.GetData(oldArr);
-
-                //int cornerX = dataWidth * (pixelizationBase - 1) / 2;
-                //int cornerY = dataHeigth * (pixelizationBase - 1) / 2;
-                //for (int x = 0; x < dataWidth; x++)
-                //{
-                //    for (int y = 0; y < dataHeigth; y++)
-                //    {
-
-                //        int smallId = x + y * dataWidth;
-                //        int bigId = x + cornerX + (y + cornerY) * otherWidth;
-                //        bigId += otherWidth * otherHeigth * register;
-                //        if (lastPixelizationLevel > pixelizationLevel)
-                //        {
-                //            smallId += dataWidth * dataHeigth * register;
-                //        }
-
-                //        smallId *= shaderPixelSize;
-                //        bigId *= shaderPixelSize;
-                //        for (int i = 0; i < shaderPixelSize; i++)
-                //        {
-                //            if (lastPixelizationLevel > pixelizationLevel)
-                //            {
-                //                newArr[bigId + i] = oldArr[smallId + i];
-                //            }
-                //            else
-                //            {
-                //                newArr[smallId + i] = oldArr[bigId + i];
-                //            }
-                //        }
-                //    }
-                //}
-                //FpMultiframeBuffer.Dispose();
-                //FpMultiframeBuffer = new ComputeBuffer(PixelCount()*2, sizeof(int) * shaderPixelSize);
-
-                //if (lastPixelizationLevel > pixelizationLevel)
-                //{
-                //    reset = false;
-                //    FpMultiframeBuffer.SetData(newArr);
-                //}
-                //else
-                //{
-                //    FpLastMultiFrameRenderBuffer.SetData(newArr);
-                //}
-
+               
+                PixelizedShaders.HandleZoomPixelization<int>(FpMultiframeBuffer, sizeof(int), lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), register, (ComputeBuffer buffer) => { FpMultiframeBuffer = buffer; }, shaderPixelSize);
+                PixelizedShaders.HandleZoomPixelization<DoublePixelPacket>(MultiFrameRenderBuffer, sizeof(double) * 2 + sizeof(int) * 2 + sizeof(float) * 2, lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), register, (ComputeBuffer buffer) => { MultiFrameRenderBuffer = buffer; });
+                
             }
             else
             {
+                MultiFrameRenderBuffer.Dispose();
+                MultiFrameRenderBuffer = new ComputeBuffer(PixelCount() * 2, sizeof(double) * 2 + sizeof(int) * 2 + sizeof(float) * 2);
                 FpMultiframeBuffer.Dispose();
-                FpMultiframeBuffer = new ComputeBuffer(PixelCount()*2, sizeof(int) * shaderPixelSize);
+                FpMultiframeBuffer = new ComputeBuffer(PixelCount() * 2, sizeof(int) * shaderPixelSize);
+                reset = true;
             }
+
+           
+            
+           
+           
 
 
 

--- a/Assets/Scripts/ShaderContolers/MandelbrotContoroler.cs
+++ b/Assets/Scripts/ShaderContolers/MandelbrotContoroler.cs
@@ -455,9 +455,9 @@ G - Toggle GUI";
             if (lastPixelizationLevel != pixelizationLevel && !upscaling)
             {
                
-                PixelizedShaders.HandleZoomPixelization<int>(FpMultiframeBuffer, sizeof(int), lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), register, (ComputeBuffer buffer) => { FpMultiframeBuffer = buffer; }, shaderPixelSize);
-                PixelizedShaders.HandleZoomPixelization<DoublePixelPacket>(MultiFrameRenderBuffer, sizeof(double) * 2 + sizeof(int) * 2 + sizeof(float) * 2, lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), register, (ComputeBuffer buffer) => { MultiFrameRenderBuffer = buffer; });
-                
+                PixelizedShaders.HandleZoomPixelization<int>(FpMultiframeBuffer, sizeof(int), lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), (ComputeBuffer buffer) => { FpMultiframeBuffer = buffer; }, shaderPixelSize);
+                PixelizedShaders.HandleZoomPixelization<DoublePixelPacket>(MultiFrameRenderBuffer, sizeof(double) * 2 + sizeof(int) * 2 + sizeof(float) * 2, lastPixelizationLevel < pixelizationLevel, GetPixelizationData(), (ComputeBuffer buffer) => { MultiFrameRenderBuffer = buffer; });
+                Debug.Log(pixelizationLevel - lastPixelizationLevel);   
             }
             else
             {

--- a/Assets/Shaders/Fractal/InfiniteShader.compute
+++ b/Assets/Shaders/Fractal/InfiniteShader.compute
@@ -54,10 +54,8 @@ int _ShiftY;
 uint _Register;
 
 RWStructuredBuffer<int> _FpMultiframeBuffer;
-RWStructuredBuffer<int> _LastMultiframeData;
 
 bool _reset;
-bool _pixelized;
 bool _pixelizationBase;
 struct res {
 	uint iter;
@@ -201,12 +199,6 @@ void CSMain(uint3 id : SV_DispatchThreadID)
 
 
 
-	}
-	else if (_pixelized) {
-		uint prePixelIdx = (id.x + id.y * width) * PixelSize;
-		for (int b = 0; b < PixelSize; b++) {
-			_FpMultiframeBuffer[pixelId + b] = _LastMultiframeData[prePixelIdx + b];
-		}
 	}
 	else if (_reset) {
 		for (int k = 0; k < PixelSize; k++) {

--- a/UserSettings/Layouts/default-2021.dwlt
+++ b/UserSettings/Layouts/default-2021.dwlt
@@ -119,7 +119,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 21
+  controlID: 39
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -144,7 +144,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 22
+  controlID: 95
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -169,7 +169,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 23
+  controlID: 96
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -187,7 +187,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 308
+    width: 287
     height: 579
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 4000, y: 4000}
@@ -211,9 +211,9 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 308
+    x: 287
     y: 0
-    width: 813
+    width: 834
     height: 579
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
@@ -233,7 +233,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ProjectBrowser
+  m_Name: ConsoleWindow
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
@@ -242,14 +242,14 @@ MonoBehaviour:
     y: 579
     width: 1121
     height: 229
-  m_MinSize: {x: 231, y: 271}
-  m_MaxSize: {x: 10001, y: 10021}
-  m_ActualView: {fileID: 15}
+  m_MinSize: {x: 101, y: 121}
+  m_MaxSize: {x: 4001, y: 4021}
+  m_ActualView: {fileID: 16}
   m_Panes:
   - {fileID: 15}
   - {fileID: 16}
-  m_Selected: 0
-  m_LastSelected: 1
+  m_Selected: 1
+  m_LastSelected: 0
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -296,9 +296,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 308
+    x: 287
     y: 72
-    width: 811
+    width: 832
     height: 558
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -603,7 +603,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 72
-    width: 307
+    width: 286
     height: 558
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -658,9 +658,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 308
+    x: 287
     y: 72
-    width: 811
+    width: 832
     height: 558
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -672,7 +672,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 1622, y: 1074}
+  m_TargetSize: {x: 1664, y: 1074}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -687,8 +687,8 @@ MonoBehaviour:
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -405.5
-    m_HBaseRangeMax: 405.5
+    m_HBaseRangeMin: -416
+    m_HBaseRangeMax: 416
     m_VBaseRangeMin: -268.5
     m_VBaseRangeMax: 268.5
     m_HAllowExceedBaseRangeMin: 1
@@ -708,23 +708,23 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 811
+      width: 832
       height: 537
     m_Scale: {x: 1, y: 1}
-    m_Translation: {x: 405.5, y: 268.5}
+    m_Translation: {x: 416, y: 268.5}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -405.5
+      x: -416
       y: -268.5
-      width: 811
+      width: 832
       height: 537
     m_MinimalGUI: 1
   m_defaultScale: 1
-  m_LastWindowPixelSize: {x: 1622, y: 1116}
+  m_LastWindowPixelSize: {x: 1664, y: 1116}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 00000000000000000000
@@ -771,21 +771,21 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Scripts/ShaderContolers
+    - Assets/Scripts/General
     m_Globs: []
     m_OriginalText: 
   m_ViewMode: 1
   m_StartGridSize: 64
   m_LastFolders:
-  - Assets/Scripts/ShaderContolers
+  - Assets/Scripts/General
   m_LastFoldersGridSize: -1
   m_LastProjectPath: C:\Users\adams\Documents\GitHub\Infinite_Fractal_Unity
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 120}
-    m_SelectedIDs: 225c0000
-    m_LastClickedID: 23586
+    m_SelectedIDs: 1e5c0000
+    m_LastClickedID: 23582
     m_ExpandedIDs: 00000000005c0000025c0000045c000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
@@ -839,8 +839,8 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: 
-    m_LastClickedInstanceID: 0
+    m_SelectedInstanceIDs: 34fbffff
+    m_LastClickedInstanceID: -1228
     m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:

--- a/UserSettings/Layouts/default-2021.dwlt
+++ b/UserSettings/Layouts/default-2021.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 1440
     height: 858
   m_ShowMode: 4
-  m_Title: Game
+  m_Title: Console
   m_RootView: {fileID: 2}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
@@ -119,7 +119,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 39
+  controlID: 28
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -144,7 +144,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 95
+  controlID: 29
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -169,7 +169,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 96
+  controlID: 30
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -206,7 +206,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: SceneView
+  m_Name: GameView
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
@@ -217,12 +217,12 @@ MonoBehaviour:
     height: 579
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
-  m_ActualView: {fileID: 12}
+  m_ActualView: {fileID: 14}
   m_Panes:
   - {fileID: 12}
   - {fileID: 14}
-  m_Selected: 0
-  m_LastSelected: 1
+  m_Selected: 1
+  m_LastSelected: 0
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -242,8 +242,8 @@ MonoBehaviour:
     y: 579
     width: 1121
     height: 229
-  m_MinSize: {x: 101, y: 121}
-  m_MaxSize: {x: 4001, y: 4021}
+  m_MinSize: {x: 100, y: 100}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 16}
   m_Panes:
   - {fileID: 15}
@@ -269,8 +269,8 @@ MonoBehaviour:
     y: 0
     width: 319
     height: 808
-  m_MinSize: {x: 276, y: 71}
-  m_MaxSize: {x: 4001, y: 4021}
+  m_MinSize: {x: 275, y: 50}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 17}
   m_Panes:
   - {fileID: 17}
@@ -612,9 +612,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 34fbffff
-      m_LastClickedID: -1228
-      m_ExpandedIDs: 36fbffff
+      m_SelectedIDs: 
+      m_LastClickedID: 0
+      m_ExpandedIDs: 34fbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -672,7 +672,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 1664, y: 1074}
+  m_TargetSize: {x: 1600, y: 800}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -680,17 +680,17 @@ MonoBehaviour:
   m_UseMipMap: 0
   m_VSyncEnabled: 0
   m_Gizmos: 0
-  m_Stats: 0
-  m_SelectedSizes: 00000000000000000000000000000000000000000000000000000000000000000000000000000000
+  m_Stats: 1
+  m_SelectedSizes: 07000000000000000000000000000000000000000000000000000000000000000000000000000000
   m_ZoomArea:
     m_HRangeLocked: 0
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -416
-    m_HBaseRangeMax: 416
-    m_VBaseRangeMin: -268.5
-    m_VBaseRangeMax: 268.5
+    m_HBaseRangeMin: -400
+    m_HBaseRangeMax: 400
+    m_VBaseRangeMin: -200
+    m_VBaseRangeMax: 200
     m_HAllowExceedBaseRangeMin: 1
     m_HAllowExceedBaseRangeMax: 1
     m_VAllowExceedBaseRangeMin: 1
@@ -699,7 +699,7 @@ MonoBehaviour:
     m_HSlider: 0
     m_VSlider: 0
     m_IgnoreScrollWheelUntilClicked: 0
-    m_EnableMouseInput: 0
+    m_EnableMouseInput: 1
     m_EnableSliderZoomHorizontal: 0
     m_EnableSliderZoomVertical: 0
     m_UniformScale: 1
@@ -784,9 +784,9 @@ MonoBehaviour:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 120}
-    m_SelectedIDs: 1e5c0000
-    m_LastClickedID: 23582
-    m_ExpandedIDs: 00000000005c0000025c0000045c000000ca9a3bffffff7f
+    m_SelectedIDs: 225c0000
+    m_LastClickedID: 23586
+    m_ExpandedIDs: 00000000005c0000025c0000045c0000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -839,8 +839,8 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: 34fbffff
-    m_LastClickedInstanceID: -1228
+    m_SelectedInstanceIDs: b4160000
+    m_LastClickedInstanceID: 5812
     m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:

--- a/UserSettings/Layouts/default-2021.dwlt
+++ b/UserSettings/Layouts/default-2021.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 1440
     height: 858
   m_ShowMode: 4
-  m_Title: Hierarchy
+  m_Title: Game
   m_RootView: {fileID: 2}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
@@ -119,7 +119,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 28
+  controlID: 21
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -144,7 +144,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 16
+  controlID: 22
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -165,11 +165,11 @@ MonoBehaviour:
     x: 0
     y: 0
     width: 1121
-    height: 591
+    height: 579
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 17
+  controlID: 23
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -187,8 +187,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 308.5
-    height: 591
+    width: 308
+    height: 579
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 13}
@@ -211,10 +211,10 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 308.5
+    x: 308
     y: 0
-    width: 812.5
-    height: 591
+    width: 813
+    height: 579
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
   m_ActualView: {fileID: 12}
@@ -233,23 +233,23 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ConsoleWindow
+  m_Name: ProjectBrowser
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 591
+    y: 579
     width: 1121
-    height: 217
-  m_MinSize: {x: 101, y: 121}
-  m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 16}
+    height: 229
+  m_MinSize: {x: 231, y: 271}
+  m_MaxSize: {x: 10001, y: 10021}
+  m_ActualView: {fileID: 15}
   m_Panes:
   - {fileID: 15}
   - {fileID: 16}
-  m_Selected: 1
-  m_LastSelected: 0
+  m_Selected: 0
+  m_LastSelected: 1
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -296,10 +296,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 308.5
+    x: 308
     y: 72
-    width: 810.5
-    height: 570
+    width: 811
+    height: 558
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -603,8 +603,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 72
-    width: 307.5
-    height: 570
+    width: 307
+    height: 558
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -612,9 +612,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 
-      m_LastClickedID: 0
-      m_ExpandedIDs: f0b2ffff3cb3ffff6ab4ffff98b5ffffe4b5ffff12b7ffff36fbffff
+      m_SelectedIDs: 34fbffff
+      m_LastClickedID: -1228
+      m_ExpandedIDs: 36fbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -658,10 +658,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 308.5
+    x: 308
     y: 72
-    width: 810.5
-    height: 570
+    width: 811
+    height: 558
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -672,7 +672,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 1621, y: 1098}
+  m_TargetSize: {x: 1622, y: 1074}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -687,10 +687,10 @@ MonoBehaviour:
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -405.25
-    m_HBaseRangeMax: 405.25
-    m_VBaseRangeMin: -274.5
-    m_VBaseRangeMax: 274.5
+    m_HBaseRangeMin: -405.5
+    m_HBaseRangeMax: 405.5
+    m_VBaseRangeMin: -268.5
+    m_VBaseRangeMax: 268.5
     m_HAllowExceedBaseRangeMin: 1
     m_HAllowExceedBaseRangeMax: 1
     m_VAllowExceedBaseRangeMin: 1
@@ -708,23 +708,23 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 810.5
-      height: 549
+      width: 811
+      height: 537
     m_Scale: {x: 1, y: 1}
-    m_Translation: {x: 405.25, y: 274.5}
+    m_Translation: {x: 405.5, y: 268.5}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -405.25
-      y: -274.5
-      width: 810.5
-      height: 549
+      x: -405.5
+      y: -268.5
+      width: 811
+      height: 537
     m_MinimalGUI: 1
   m_defaultScale: 1
-  m_LastWindowPixelSize: {x: 1621, y: 1140}
+  m_LastWindowPixelSize: {x: 1622, y: 1116}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 00000000000000000000
@@ -751,9 +751,9 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 663
+    y: 651
     width: 1120
-    height: 196
+    height: 208
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -783,10 +783,10 @@ MonoBehaviour:
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
-    scrollPos: {x: 0, y: 60}
-    m_SelectedIDs: 505c0000
-    m_LastClickedID: 23632
-    m_ExpandedIDs: 00000000005c0000205c0000225c000000ca9a3bffffff7f
+    scrollPos: {x: 0, y: 120}
+    m_SelectedIDs: 225c0000
+    m_LastClickedID: 23586
+    m_ExpandedIDs: 00000000005c0000025c0000045c000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -814,7 +814,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000005c0000
+    m_ExpandedIDs: 00000000005c0000025c0000045c0000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -891,9 +891,9 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 663
+    y: 651
     width: 1120
-    height: 196
+    height: 208
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default


### PR DESCRIPTION
created a generic function that accepts any type of pixel data
fixed a bug when thread groups is calculated as a non int number
performance issue: 
gettind data from gpu takes a lot of time in some cases around 500 ms per pixelization
plans: make a general use shader that pixelizes and copies the data directly on the gpu